### PR TITLE
add repo URL to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate, rmarkdown
-URL: https://rmi-pacta.github.io/pacta.loanbook/
+URL: https://rmi-pacta.github.io/pacta.loanbook/, https://github.com/rmi-pacta/pacta.loanbook
 Imports: 
     cli,
     dplyr,


### PR DESCRIPTION
this should make the GitHub icon/link appear on the pkgdown site as expected