### PR TITLE
add CRAN incoming R CMD check CI

### DIFF
--- a/.github/workflows/R-CMD-check-CRAN-incoming.yaml
+++ b/.github/workflows/R-CMD-check-CRAN-incoming.yaml
@@ -1,0 +1,103 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check-CRAN-incoming.yaml
+
+permissions:
+  pull-requests: write
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 25
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: 'devel'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck, any::crayon, any::xml2
+          needs: check
+
+      - name: Install aspell on Windows
+        if: ${{ runner.os=='Windows' }}
+        run: |
+          pacman -S --noconfirm aspell aspell-en
+
+      - name: Install aspell on Ubuntu
+        if: ${{ runner.os=='Linux' }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y aspell aspell-en
+
+      - name: Install aspell on macOS
+        if: ${{ runner.os=='macOS' }}
+        run: |
+          brew install aspell
+
+      - name: R CMD check CRAN incoming feasibilty
+        id: rcmdcheck
+        run: |
+          cat("::group::Run R CMD check with CRAN incoming env vars\n")
+          options(crayon.enabled = TRUE)
+          cat("LOGNAME=", Sys.info()[["user"]], "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+          Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
+          Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "true")
+          Sys.setenv("_R_CHECK_CRAN_INCOMING_REMOTE_" = "true")
+          Sys.setenv("_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "true")
+          cat("check-dir-path=", file.path(getwd(), "check"), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+          check_results <- rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), build_args = c("--no-manual", "--compact-vignettes=gs+qpdf"), error_on = "never", check_dir = "check")
+          writeLines(paste0("```\n", check_results$stdout, "\n```"), Sys.getenv("GITHUB_STEP_SUMMARY"))
+          notes <- unlist(strsplit(check_results$notes, "\\n"))
+          notes <- grep("^checking CRAN incoming feasibility|^Maintainer: |^New submission$|^Version contains large components |^Days since last update: |^$", notes, value = TRUE, invert = TRUE)
+          writeLines(paste0("R CMD check CRAN incoming feasibility check notes found:\n```\n", paste(notes, collapse = "\n"), "\n```"), "notes.md")
+          if (length(notes) > 0L) { cat("::error::Notes found in CRAN incoming feasibility check\n"); cat(paste(notes, collapse = "\n")) }
+          cat("notes=", length(notes), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Upload 00check.log
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ format('{0}-{1}-r{2}-{3}-00check.log', runner.os, runner.arch, matrix.config.r, matrix.config.id || strategy.job-index ) }}
+          path: ${{ steps.rcmdcheck.outputs.check-dir-path }}/*.Rcheck/00check.log
+          if-no-files-found: ignore
+
+      - name: Find Comment
+        if: steps.rcmdcheck.outputs.notes > 0
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+
+      - name: Create or update comment
+        if: steps.rcmdcheck.outputs.notes > 0
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: "notes.md"
+          edit-mode: replace


### PR DESCRIPTION
[as we have in pacta.multi.loanbook](https://github.com/RMI-PACTA/pacta.multi.loanbook/blob/main/.github/workflows/R-CMD-check-CRAN-incoming.yaml) that is supposed to never fail, but will post a comment in the PR thread if CRAN incoming notes are found