### PR TITLE
bump required R version to >=4.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         config:
           - {os: macos-latest,   r: 'release'}
-          - {os: macos-latest,   r: '4.1'}
+          - {os: macos-13,   r: '4.0'}
 
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '4.0'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,15 +23,16 @@ jobs:
       matrix:
         config:
           - {os: macos-latest,   r: 'release'}
+          - {os: macos-latest,   r: '4.0'}
 
           - {os: windows-latest, r: 'release'}
-          # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6'}
+          - {os: windows-latest, r: '4.0'}
           # use 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: '4.1'}
 
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: '4.0'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: 'oldrel-2'}
           - {os: ubuntu-latest,   r: 'oldrel-3'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         config:
           - {os: macos-latest,   r: 'release'}
-          - {os: macos-latest,   r: '4.0'}
+          - {os: macos-latest,   r: '4.1'}
 
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '4.0'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     mockr,
     readr,
     readxl,
-    rmarkdown,
+    rmarkdown (>= 2.19),
     spelling,
     testthat (>= 3.0.0),
     writexl

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
     DiagrammeR,
     ggplot2,
     glue,
-    gt,
+    gt (>= 0.11.0),
     knitr,
     mockr,
     readr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Suggests:
     readxl,
     rmarkdown (>= 2.19),
     spelling,
-    testthat (>= 3.0.0),
+    testthat (>= 3.2.2),
     writexl
 Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate, rmarkdown
 URL: https://rmi-pacta.github.io/pacta.loanbook/, https://github.com/rmi-pacta/pacta.loanbook

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Depends:
+    R (>= 4.0.0)
 Suggests: 
     covr,
     DiagrammeR,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     ggplot2,
     glue,
     gt (>= 0.11.0),
-    knitr,
+    knitr (>= 1.42),
     mockr,
     readr,
     readxl,


### PR DESCRIPTION
also:
- bump gt (>= 0.11.0) for interactive table options
- bump knitr (>= 1.42) so it's recognized by `tools:::loadVignetteBuilder()`
- bump rmarkdown (>= 2.19) so it doesn't use deprecated `xfun::isFALSE()`
- bump testthat (>= 3.2.2) for `waldo::compare()` fixes/improvements