### PR TITLE
move external article links to the Packages menu

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -37,7 +37,7 @@ reference:
 
 navbar:
   structure:
-    left:  [intro, cookbook, data, reference, articles, news]
+    left:  [intro, cookbook, data, reference, news]
     right: [search, packages, github]
   components:
     cookbook:
@@ -68,22 +68,6 @@ navbar:
         href: articles/data_classification.html
       - text: PACTA Outputs
         href: articles/data_outputs.html
-    articles:
-      text: Articles
-      menu:
-      - text: r2dii.match
-      - text: Calculating Matching Coverage
-        href: https://rmi-pacta.github.io/r2dii.match/articles/matching-coverage.html
-      - text: Using match_name() with large loanbooks
-        href: https://rmi-pacta.github.io/r2dii.match/articles/chunk-your-data.html
-      - text: ---
-      - text: r2dii.analysis
-      - text: Sectoral Decarbonization Approach (SDA)
-        href: https://rmi-pacta.github.io/r2dii.analysis/articles/target-sda.html
-      - text: Market Share Approach
-        href: https://rmi-pacta.github.io/r2dii.analysis/articles/target-market-share.html
-      - text: "Indicator Choices: Weighted Production vs. Weighted Percent Change in Production"
-        href: https://rmi-pacta.github.io/r2dii.analysis/articles/production-percent-change.html
     packages:
       text: Packages
       menu:
@@ -100,3 +84,18 @@ navbar:
       - text: ---
       - text: sit.rep
         href: articles/pacta_loanbook_sit_rep.html
+      - text: ---
+      - text: Articles
+      - text: r2dii.match
+      - text: Calculating Matching Coverage
+        href: https://rmi-pacta.github.io/r2dii.match/articles/matching-coverage.html
+      - text: Using match_name() with large loanbooks
+        href: https://rmi-pacta.github.io/r2dii.match/articles/chunk-your-data.html
+      - text: ---
+      - text: r2dii.analysis
+      - text: Sectoral Decarbonization Approach (SDA)
+        href: https://rmi-pacta.github.io/r2dii.analysis/articles/target-sda.html
+      - text: Market Share Approach
+        href: https://rmi-pacta.github.io/r2dii.analysis/articles/target-market-share.html
+      - text: "Indicator Choices: Weighted Production vs. Weighted Percent Change in Production"
+        href: https://rmi-pacta.github.io/r2dii.analysis/articles/production-percent-change.html


### PR DESCRIPTION
- related #131 

Until all external (from r2dii packages docs) articles have been migrated/replicated here, I still think it's a good idea to link to them, but maybe best to de-emphasize external content by including them in the "Packages" menu (which has other external links).