### PR TITLE
remove dontrun directives in examples

### DIFF
--- a/R/r2dii.match.R
+++ b/R/r2dii.match.R
@@ -6,6 +6,60 @@ crucial_lbk <- r2dii.match::crucial_lbk
 
 
 #' @inherit r2dii.match::match_name
+#' @examples
+#' library(r2dii.data)
+#' library(tibble)
+#'
+#' # Small data for examples
+#' loanbook <- head(loanbook_demo, 50)
+#' abcd <- head(abcd_demo, 50)
+#'
+#' match_name(loanbook, abcd)
+#'
+#' match_name(loanbook, abcd, min_score = 0.9)
+#'
+#' # match on LEI
+#' loanbook <- tibble(
+#'   sector_classification_system = "NACE",
+#'   sector_classification_direct_loantaker = "D35.11",
+#'   id_ultimate_parent = "UP15",
+#'   name_ultimate_parent = "Won't fuzzy match",
+#'   id_direct_loantaker = "C294",
+#'   name_direct_loantaker = "Won't fuzzy match",
+#'   lei_direct_loantaker = "LEI123"
+#' )
+#'
+#' abcd <- tibble(
+#'   name_company = "alpine knits india pvt. limited",
+#'   sector = "power",
+#'   lei = "LEI123"
+#' )
+#'
+#' match_name(loanbook, abcd, join_id = c(lei_direct_loantaker = "lei"))
+#'
+#' # Use your own `sector_classifications`
+#' your_classifications <- tibble(
+#'   sector = "power",
+#'   borderline = FALSE,
+#'   code = "D35.11",
+#'   code_system = "XYZ"
+#' )
+#'
+#' loanbook <- tibble(
+#'   sector_classification_system = "XYZ",
+#'   sector_classification_direct_loantaker = "D35.11",
+#'   id_ultimate_parent = "UP15",
+#'   name_ultimate_parent = "Alpine Knits India Pvt. Limited",
+#'   id_direct_loantaker = "C294",
+#'   name_direct_loantaker = "Yuamen Xinneng Thermal Power Co Ltd"
+#' )
+#'
+#' abcd <- tibble(
+#'   name_company = "alpine knits india pvt. limited",
+#'   sector = "power"
+#' )
+#'
+#' match_name(loanbook, abcd, sector_classification = your_classifications)
 #' @family matching functions
 #' @export
 

--- a/R/update.R
+++ b/R/update.R
@@ -14,9 +14,7 @@
 #'   of printing the status of locally installed, relevant packages.
 #'
 #' @examples
-#' \dontrun{
-#' pacta_loanbook_update()
-#' }
+#' pacta_loanbook_update(repos = "https://cran.r-project.org")
 
 pacta_loanbook_update <- function(recursive = FALSE, repos = getOption("repos")) {
 
@@ -50,6 +48,9 @@ pacta_loanbook_update <- function(recursive = FALSE, repos = getOption("repos"))
 #' quick idea of what's going on when you're helping someone else debug a
 #' problem.
 #'
+#' @param repos The repositories to use to check for updates.
+#'   Defaults to \code{getOption("repos")}.
+#'
 #' @family utility functions
 #'
 #' @export
@@ -58,18 +59,16 @@ pacta_loanbook_update <- function(recursive = FALSE, repos = getOption("repos"))
 #'   of printing a situation report of `{pacta.loanbook}` and its core packages.
 #'
 #' @examples
-#' \dontrun{
-#' pacta_loanbook_sitrep()
-#' }
+#' pacta_loanbook_sitrep(repos = "https://cran.r-project.org")
 
-pacta_loanbook_sitrep <- function() {
+pacta_loanbook_sitrep <- function(repos = getOption("repos")) {
   cli::cat_rule("R & RStudio")
   if (rstudioapi::isAvailable()) {
     cli::cat_bullet("RStudio: ", rstudioapi::getVersion())
   }
   cli::cat_bullet("R: ", getRversion())
 
-  deps <- pacta_loanbook_deps()
+  deps <- pacta_loanbook_deps(repos = repos)
   package_pad <- format(deps$package)
   packages <- ifelse(
     deps$behind,
@@ -98,9 +97,7 @@ pacta_loanbook_sitrep <- function() {
 #'   packages.
 #'
 #' @examples
-#' \dontrun{
-#' pacta_loanbook_deps()
-#' }
+#' pacta_loanbook_deps(repos = "https://cran.r-project.org")
 
 pacta_loanbook_deps <- function(recursive = FALSE, repos = getOption("repos")) {
   pkgs <- utils::available.packages(repos = repos)

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -107,7 +107,6 @@ This function ignores but preserves existing groups.
 }
 
 \examples{
-\dontrun{
 library(r2dii.data)
 library(tibble)
 
@@ -161,10 +160,6 @@ abcd <- tibble(
 )
 
 match_name(loanbook, abcd, sector_classification = your_classifications)
-
-# Cleanup
-options(restore)
-}
 }
 \seealso{
 Other matching functions: 

--- a/man/pacta_loanbook_deps.Rd
+++ b/man/pacta_loanbook_deps.Rd
@@ -21,9 +21,7 @@ packages.
 List all \code{{pacta.loanbook}} dependencies
 }
 \examples{
-\dontrun{
-pacta_loanbook_deps()
-}
+pacta_loanbook_deps(repos = "https://cran.r-project.org")
 }
 \seealso{
 Other utility functions: 

--- a/man/pacta_loanbook_sitrep.Rd
+++ b/man/pacta_loanbook_sitrep.Rd
@@ -4,7 +4,11 @@
 \alias{pacta_loanbook_sitrep}
 \title{Get a situation report on \code{{pacta.loanbook}}}
 \usage{
-pacta_loanbook_sitrep()
+pacta_loanbook_sitrep(repos = getOption("repos"))
+}
+\arguments{
+\item{repos}{The repositories to use to check for updates.
+Defaults to \code{getOption("repos")}.}
 }
 \value{
 returns \code{NULL} invisibly. The function is called for its side effect
@@ -17,9 +21,7 @@ quick idea of what's going on when you're helping someone else debug a
 problem.
 }
 \examples{
-\dontrun{
-pacta_loanbook_sitrep()
-}
+pacta_loanbook_sitrep(repos = "https://cran.r-project.org")
 }
 \seealso{
 Other utility functions: 

--- a/man/pacta_loanbook_update.Rd
+++ b/man/pacta_loanbook_update.Rd
@@ -23,9 +23,7 @@ their dependencies) are up-to-date, and will install after an interactive
 confirmation.
 }
 \examples{
-\dontrun{
-pacta_loanbook_update()
-}
+pacta_loanbook_update(repos = "https://cran.r-project.org")
 }
 \seealso{
 Other utility functions: 


### PR DESCRIPTION
- resolves #201 

For `pacta_loanbook_deps()`, `pacta_loanbook_sitrep()`, and `pacta_loanbook_update()` tidyverse does the same thing except they don't include any example, which I guess they can get away with because their grandfathered in, but we obviously cannot. The examples fail because a CRAN repo is not set when testing the example. I tried setting the option in the example with `options(repos = list(CRAN="http://cran.rstudio.com/"))` first but that also failed and didn't seem like a good idea anyway. Explicitly using the preexisting `repos` argument and adding it to `pacta_loanbook_sitrep()` allows me to pass it through the chain of functions and the examples run without error. 🤷🏻 

For the `match_name()` example, the dontrun directive was added in https://github.com/RMI-PACTA/r2dii.match/commit/76a7e8bb91836515b524bb978bda8cb0193e7f24 with no explanation, so here I'm overriding the inherited example from `r2dii.match::match_name()` with the same but without the dontrun directive (and also removing the trailing reset of an option which is leftover from before and should be removed: see https://github.com/RMI-PACTA/r2dii.match/pull/532)