### PR TITLE
Update R-CMD-check-CRAN-incoming.yaml

### DIFF
--- a/.github/workflows/R-CMD-check-CRAN-incoming.yaml
+++ b/.github/workflows/R-CMD-check-CRAN-incoming.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'devel'}
+          - {os: windows-latest, r: 'devel', http-user-agent: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action has suddenly started trying to download pkgs for R 4.6, which don't exist. Maybe setting `http-user-agent: 'release'` will make it download the appropriate pkgs?