### PR TITLE
remove overridden r2dii.plot examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Imports:
     r2dii.analysis (>= 0.5.1),
     r2dii.data (>= 0.6.0),
     r2dii.match (>= 0.4.0),
-    r2dii.plot (>= 0.5.1),
+    r2dii.plot (>= 0.5.2),
     rlang,
     rstudioapi,
     scales,

--- a/R/r2dii.plot.R
+++ b/R/r2dii.plot.R
@@ -1,10 +1,4 @@
 #' @inherit r2dii.plot::plot_emission_intensity
-#' @examples
-#' # plot with `qplot_emission_intensity()` parameters
-#' data <- subset(sda, sector == "cement" & region == "global")
-#' data <- prep_emission_intensity(data, span_5yr = TRUE, convert_label = to_title)
-#'
-#' plot_emission_intensity(data)
 #' @family plotting functions
 #' @export
 
@@ -12,23 +6,6 @@ plot_emission_intensity <- r2dii.plot::plot_emission_intensity
 
 
 #' @inherit r2dii.plot::plot_techmix
-#' @examples
-#' # plot with `qplot_techmix()` parameters
-#' data <- subset(
-#'   market_share,
-#'   scenario_source == "demo_2020" &
-#'     sector == "power" &
-#'     region == "global" &
-#'     metric %in% c("projected", "corporate_economy", "target_sds")
-#' )
-#' data <- prep_techmix(
-#'   data,
-#'   span_5yr = TRUE,
-#'   convert_label = recode_metric_techmix,
-#'   convert_tech_label = spell_out_technology
-#' )
-#'
-#' plot_techmix(data)
 #' @family plotting functions
 #' @export
 
@@ -36,22 +13,6 @@ plot_techmix <- r2dii.plot::plot_techmix
 
 
 #' @inherit r2dii.plot::plot_trajectory
-#' @examples
-#' # plot with `qplot_trajectory()` parameters
-#' data <- subset(
-#'   market_share,
-#'   sector == "power" &
-#'     technology == "renewablescap" &
-#'     region == "global" &
-#'     scenario_source == "demo_2020"
-#' )
-#' data <- prep_trajectory(data)
-#'
-#' plot_trajectory(
-#'   data,
-#'   center_y = TRUE,
-#'   perc_y_scale = TRUE
-#' )
 #' @family plotting functions
 #' @export
 


### PR DESCRIPTION
- depends on https://github.com/RMI-PACTA/r2dii.plot/pull/607
- depends on new version of r2dii.plot released on CRAN

- resolves #225 