### PR TITLE
add RMI ROR ID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Authors@R:
       person(
         given = "RMI",
         role = c("cph", "fnd"),
-        email = "PACTA4banks@rmi.org"
+        email = "PACTA4banks@rmi.org",
+        comment = c(ROR = "03anfar33")
       )
     )
 Description: PACTA (Paris Agreement Capital Transition Assessment) for Banks is


### PR DESCRIPTION
Apparently RMI has a [Research Organization Registry (ROR) ID](https://ror.org/03anfar33), CRAN is now [automatically linking them](https://bsky.app/profile/zeileis.org/post/3lgpshnevkk2v), and pkgdown will [auto link them soon](https://github.com/r-lib/pkgdown/pull/2851).