### PR TITLE
Add code snippet for comp level plots

### DIFF
--- a/vignettes/articles/cookbook_running_the_analysis.Rmd
+++ b/vignettes/articles/cookbook_running_the_analysis.Rmd
@@ -658,7 +658,7 @@ economy, or against various scenario targets.
 
 ```{r technoloy-mix-portfolio}
 # Pick the targets you want to plot.
-data <- filter(
+data_portfolio <- filter(
   market_share_targets_portfolio,
   scenario_source == "demo_2020",
   sector == "power",
@@ -667,7 +667,27 @@ data <- filter(
 )
 
 # Plot the technology mix
-qplot_techmix(data)
+qplot_techmix(data_portfolio)
+```
+
+To obtain the technology mix chart for an individual company in your portfolio,
+you can run the following code (notice that we do not actually run the code here,
+as the output plot will look structurally almost the same as the tech mix plot for a portfolio):
+
+```{r technoloy-mix-company, eval = FALSE}
+# Pick the targets you want to plot.
+data_company <- filter(
+  market_share_targets_company,
+  # provide the name of the company and "corporate_economy" to select the relevant emission intensity pathways
+  name_abcd %in% c("Mariani-Mariani s.r.l.", "corporate_economy"),
+  scenario_source == "demo_2020",
+  sector == "power",
+  region == "global",
+  metric %in% c("projected", "corporate_economy", "target_sds")
+)
+
+# Plot the technology mix
+qplot_techmix(data_company)
 ```
 
 ### Market Share: Technology-level volume trajectory
@@ -677,7 +697,7 @@ normalized to 1, to emphasize that we are comparing the rates of build-out and/o
 retirement. 
 
 ```{r trajetory-portfolio}
-data <- filter(
+data_portfolio <- filter(
   market_share_targets_portfolio,
   sector == "power",
   technology == "renewablescap",
@@ -685,7 +705,26 @@ data <- filter(
   scenario_source == "demo_2020"
 )
 
-qplot_trajectory(data)
+qplot_trajectory(data_portfolio)
+```
+
+Again, the volume trajectory chart for an individual company in your portfolio
+can be obtained by running the following code (notice that we do not actually
+run the code here, as the output plot will look structurally almost the same as the volume
+trajectory plot for a portfolio):
+
+```{r trajetory-company, eval = FALSE}
+data_company <- filter(
+  market_share_targets_company,
+  # provide the name of the company and "corporate_economy" to select the relevant emission intensity pathways
+  name_abcd %in% c("Mariani-Mariani s.r.l.", "corporate_economy"),
+  sector == "power",
+  technology == "renewablescap",
+  region == "global",
+  scenario_source == "demo_2020"
+)
+
+qplot_trajectory(data_company)
 ```
 
 ### SDA Target: Sector-level emission intensity
@@ -696,8 +735,31 @@ the scenario compliant SDA pathway that the portfolio must follow to achieve
 the scenario ambition by 2050.
 
 ```{r sda plot}
-data <- filter(sda_targets_portfolio, sector == "cement", region == "global")
-qplot_emission_intensity(data)
+data_portfolio <- filter(
+  sda_targets_portfolio,
+  sector == "cement",
+  region == "global"
+)
+
+qplot_emission_intensity(data_portfolio)
+```
+
+The emission intensity plot can also be plotted for an individual company. 
+Similarly to the above cases, you can create the company-level emissions intensity
+plot by running the following code (notice that we do not actually run the code
+here, as the output plot will look structurally almost the same as the emission intensity plot
+for a portfolio):
+
+```{r sda plot company, eval = FALSE}
+data_company <- filter(
+  sda_targets_company,
+  # provide the name of the company and "market" to select the relevant emission intensity pathways
+  name_abcd %in% c("Kramer GmbH & Co. OHG", "market"),
+  sector == "cement",
+  region == "global"
+)
+
+qplot_emission_intensity(data_company)
 ```
 
 ### Exporting plots to an image file
@@ -705,7 +767,7 @@ qplot_emission_intensity(data)
 All of the functions from `{pacta.loanbook}` that produce plots, e.g. `qplot_techmix()` and `plot_trajectory()`, return a `ggplot` object, which can be saved as an image file using the `ggplot2::ggsave()` function, for example:
 
 ```{r save_plot_to_file}
-emission_intensity_plot <- qplot_emission_intensity(data)
+emission_intensity_plot <- qplot_emission_intensity(data_portfolio)
 
 ggplot2::ggsave(
   filename = file.path(tempdir(), "emission_intensity_plot.png"),

--- a/vignettes/articles/cookbook_running_the_analysis.Rmd
+++ b/vignettes/articles/cookbook_running_the_analysis.Rmd
@@ -610,7 +610,7 @@ The [Sectoral Decarbonization Approach](cookbook_metrics.html#sectoral-decarboni
 # Use this dataset to practice but eventually you should use your own data.
 co2 <- co2_intensity_scenario_demo
 
-sda_targets <-
+sda_targets_portfolio <-
   target_sda(
     data = prioritized_matches,
     abcd = abcd,
@@ -619,7 +619,7 @@ sda_targets <-
   ) %>% 
   filter(sector == "cement", year >= 2020)
 
-sda_targets
+sda_targets_portfolio
 ```
 
 or at the company level:
@@ -640,7 +640,7 @@ sda_targets_company
 These results can be saved/written to a CSV file for potential input to other models and software, for example:
 
 ```{r}
-readr::write_csv(x = sda_targets, file = file.path(tempdir(), "sda_targets.csv"))
+readr::write_csv(x = sda_targets_portfolio, file = file.path(tempdir(), "sda_targets_portfolio.csv"))
 readr::write_csv(x = sda_targets_company, file = file.path(tempdir(), "sda_targets_company.csv"))
 ```
 
@@ -696,7 +696,7 @@ the scenario compliant SDA pathway that the portfolio must follow to achieve
 the scenario ambition by 2050.
 
 ```{r sda plot}
-data <- filter(sda_targets, sector == "cement", region == "global")
+data <- filter(sda_targets_portfolio, sector == "cement", region == "global")
 qplot_emission_intensity(data)
 ```
 


### PR DESCRIPTION
closes Monday ticket: https://rmi.monday.com/boards/8225089626/pulses/8872836590

- adds code snippets that describe how to generate the PACTA plots for an individual company in the loan book
- those new snippets are not evaluated, as the plots would structurally be identical to the portfolio level plots. Showing almost identical plots twice in a row would clutter the cookbook.
- some renaming of objects for clarification