### PR TITLE
use macos-latest runner for R v4.1 testing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,6 +52,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          extra-repositories: 'https://packagemanager.posit.co/cran/latest'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,11 +52,13 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          extra-repositories: 'https://packagemanager.posit.co/cran/latest'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          upgrade: 'TRUE'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         config:
           - {os: macos-latest,   r: 'release'}
-          - {os: macos-13,   r: '4.1'}
+          - {os: macos-latest,   r: '4.1'}
 
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: '4.1'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-          upgrade: 'TRUE'
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          extra-repositories: 'https://packagemanager.posit.co/cran/latest'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
- closes #257 

It appears that a macos-13 runner was needed to run R v4.0, but in #248 the minimum R version was bumped to v4.1, and presumably macos-latest can be used for R v4.1. Additionally, a binary version of {igraph} for macOS on arm64 is available on Posit Package Manager:
https://packagemanager.posit.co/client/#/repos/cran/packages/overview?search=igraph&distribution=macos
https://packagemanager.posit.co/cran/latest/bin/macosx/big-sur-arm64/contrib/4.1/igraph_2.1.4.tgz

update: Looks like adding the Posit Package Manager URL as an "extra-repository" in the setup-R part is also necessary for it to pickup the binaries.