### PR TITLE
manually fix link in `target_sda()` docs…

### DIFF
--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -42,7 +42,7 @@ the column \code{name_abcd}.
 This function calculates targets of
 \ifelse{html}{\out{CO<sub>2</sub>}}{\eqn{CO_2}{CO~2~}} emissions per unit
 production at the portfolio-level, otherwise referred to as "emissions
-factors". It uses the \href{https://rmi-pacta.github.io/r2dii.analysis/articles/sda-target.html}{sectoral-decarbonization approach (SDA)}
+factors". It uses the \href{https://rmi-pacta.github.io/r2dii.analysis/articles/target-sda.html}{sectoral-decarbonization approach (SDA)}
 to calculate these targets.
 }
 \section{Handling grouped data}{


### PR DESCRIPTION
…since fix in {r2dii.analysis} has not been released yet. (Normally this documentation is imported from the latest release version of {r2dii.analysis})

- closes #260 